### PR TITLE
 Implement rocket booking, booking cancelation and switch badges for Rockets

### DIFF
--- a/src/components/ListRockets.js
+++ b/src/components/ListRockets.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { reserveRocket, cancelReservation } from '../redux/rockets/rocketsReducer';
+import {
+  reserveRocket,
+  cancelReservation,
+} from '../redux/rockets/rocketsReducer';
 
 const ListRockets = (props) => {
   const {
@@ -23,23 +26,43 @@ const ListRockets = (props) => {
   return (
     <div>
       <div className="flex space-x-10">
-        <div><img className="flex-none w-80" src={flickrImages} alt="Rocket" /></div>
+        <div>
+          <img className="flex-none w-80" src={flickrImages} alt="Rocket" />
+        </div>
         <div className="flex-none flex flex-col space-y-4 w-8/12">
           <div>
             <div className="text-3xl">{rocketName}</div>
           </div>
           <div>
-            <div className="bg-emerald-400 text-xs text-white p-2 rounded w-24">{reserve ? 'Reserved' : 'Not reserved'}</div>
+            {reserve ? (
+              <div>
+                <div className="bg-emerald-400 text-xs text-white p-2 m-1 rounded w-16">
+                  Reserved
+                </div>
+                <div>{description}</div>
+              </div>
+            ) : (
+              description
+            )}
           </div>
-          <div>{description}</div>
           <div>
-            <button
-              onClick={handleReservation}
-              className="bg-blue-600 text-white p-3 rounded"
-              type="button"
-            >
-              {reserve ? 'Cancel Reservation' : 'Reserve Rocket'}
-            </button>
+            {reserve ? (
+              <button
+                onClick={handleReservation}
+                className="bg-inherit border-solid border-2 text-lg text-gray-500 border-gray-400 p-2 rounded"
+                type="button"
+              >
+                Cancel Reservation
+              </button>
+            ) : (
+              <button
+                onClick={handleReservation}
+                className="bg-blue-600 text-white p-2 w-40 text-lg  rounded"
+                type="button"
+              >
+                Reserve Rocket
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/ListRockets.js
+++ b/src/components/ListRockets.js
@@ -35,8 +35,8 @@ const ListRockets = (props) => {
           </div>
           <div>
             {reserve ? (
-              <div>
-                <div className="bg-emerald-400 text-xs text-white p-2 m-1 rounded w-16">
+              <div className="gap-4">
+                <div className="bg-teal-600 text-sm text-white rounded mt-1 text-center mr-4 align-middle h-5 w-20 float-left">
                   Reserved
                 </div>
                 <div>{description}</div>

--- a/src/components/ListRockets.js
+++ b/src/components/ListRockets.js
@@ -1,12 +1,23 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { reserveRocket } from '../redux/rockets/rocketsReducer';
 
 const ListRockets = (props) => {
   const {
     rocket: {
-      flickrImages, rocketName, description, reserve,
+      flickrImages, rocketName, description, reserve, id,
     },
   } = props;
+
+  const dispatch = useDispatch();
+
+  const handleReservation = () => {
+    if (reserve) {
+      dispatch(reserveRocket(id));
+    }
+    console.log('reserve button is clicked and reserve is ', reserve);
+  };
 
   return (
     <div>
@@ -21,7 +32,13 @@ const ListRockets = (props) => {
           </div>
           <div>{description}</div>
           <div>
-            <button className="bg-blue-600 text-white p-3 rounded" type="button">Reserve Rocket</button>
+            <button
+              onClick={handleReservation}
+              className="bg-blue-600 text-white p-3 rounded"
+              type="button"
+            >
+              {reserve ? 'Cancel Reservation' : 'Reserve Rocket'}
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/ListRockets.js
+++ b/src/components/ListRockets.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PropTypes } from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { reserveRocket } from '../redux/rockets/rocketsReducer';
+import { reserveRocket, cancelReservation } from '../redux/rockets/rocketsReducer';
 
 const ListRockets = (props) => {
   const {
@@ -14,9 +14,10 @@ const ListRockets = (props) => {
 
   const handleReservation = () => {
     if (reserve) {
+      dispatch(cancelReservation(id));
+    } else {
       dispatch(reserveRocket(id));
     }
-    console.log('reserve button is clicked and reserve is ', reserve);
   };
 
   return (

--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -8,7 +8,7 @@ import { fetchingData } from '../redux/rockets/rocketsReducer';
 import store from '../redux/configureStore';
 
 const Rockets = () => {
-  const rocketsFromStore = useSelector((store) => store.rocketsReducer);
+  const rocketsFromStore = useSelector((state) => state.rocketsReducer);
 
   const dispatch = useDispatch();
 
@@ -21,7 +21,7 @@ const Rockets = () => {
   return (
     <div>
       <div className="grid m-12">
-        {rocketsFromStore.map((rocket) => (
+        {rocketsFromStore[0] && rocketsFromStore[0].map((rocket) => (
           <ListRockets key={v4()} rocket={rocket} />
         ))}
       </div>

--- a/src/redux/rockets/rocketsReducer.js
+++ b/src/redux/rockets/rocketsReducer.js
@@ -1,10 +1,16 @@
 // *Constants
 const FETCH_ROCKET = 'FETCH_ROCKET';
+const RESERVE_ROCKET = 'RESERVE_ROCKET';
 
 // *Actions
 // Store data
 const storerockets = (payload) => ({
   type: FETCH_ROCKET,
+  payload,
+});
+
+export const reserveRocket = (payload) => ({
+  type: RESERVE_ROCKET,
   payload,
 });
 
@@ -31,9 +37,15 @@ const rocketsReducer = (state = [], action) => {
           rocketName: rocket.rocket_name,
           description: rocket.description,
           id: rocket.rocket_id,
-          reserved: false,
+          reserve: false,
         })),
       ][0];
+    case RESERVE_ROCKET:
+        return [
+          state[0].map((rocket) =>
+            rocket.rocket_id == action.payload ? { ...rocket, reserve: true } : rocket
+          ),
+        ];
     default:
       return state;
   }

--- a/src/redux/rockets/rocketsReducer.js
+++ b/src/redux/rockets/rocketsReducer.js
@@ -1,16 +1,22 @@
 // *Constants
 const FETCH_ROCKET = 'FETCH_ROCKET';
 const RESERVE_ROCKET = 'RESERVE_ROCKET';
+const CANCEL_ROCKET = 'CANCEL_ROCKET';
 
 // *Actions
 // Store data
-const storerockets = (payload) => ({
+const storeRockets = (payload) => ({
   type: FETCH_ROCKET,
   payload,
 });
 
 export const reserveRocket = (payload) => ({
   type: RESERVE_ROCKET,
+  payload,
+});
+
+export const cancelReservation = (payload) => ({
+  type: CANCEL_ROCKET,
   payload,
 });
 
@@ -21,7 +27,7 @@ export const fetchingData = () => async (dispatch) => {
   });
   try {
     const rockets = await data.json();
-    dispatch(storerockets(rockets));
+    dispatch(storeRockets(rockets));
   } catch (error) {
     console.error(error);
   }
@@ -39,13 +45,17 @@ const rocketsReducer = (state = [], action) => {
           id: rocket.rocket_id,
           reserve: false,
         })),
-      ][0];
+      ];
     case RESERVE_ROCKET:
-        return [
-          state[0].map((rocket) =>
-            rocket.rocket_id == action.payload ? { ...rocket, reserve: true } : rocket
-          ),
-        ];
+      return [
+        state[0].map((rocket) => (rocket.id === action.payload
+          ? { ...rocket, reserve: true } : rocket)),
+      ];
+    case CANCEL_ROCKET:
+      return [
+        state[0].map((rocket) => (rocket.id === action.payload
+          ? { ...rocket, reserve: false } : rocket)),
+      ];
     default:
       return state;
   }


### PR DESCRIPTION
### In this PR:

- When a user clicks the "Reserve rocket" button, booking action is dispatched to update the store. 
- When a user clicks the "Cancel Reservation" button, booking cancelation action is dispatched to update the store. 
- Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design).

Close #12, Close #8, and Close #5 